### PR TITLE
Add setting for anaconda mirror

### DIFF
--- a/bootstrap-scripts/saltmaster.sh
+++ b/bootstrap-scripts/saltmaster.sh
@@ -121,6 +121,14 @@ cloudera:
 EOF
 fi
 
+if [ "x$ANACONDA_MIRROR" != "x" ] ; then
+cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
+anaconda:
+  parcel_version: "4.0.0"
+  parcel_repo: '$ANACONDA_MIRROR'
+EOF
+fi
+
 if [ "x$PACKAGES_SERVER_URI" != "x" ] ; then
 cat << EOF >> /srv/salt/platform-salt/pillar/env_parameters.sls
 packages_server:

--- a/pnda_env.sh
+++ b/pnda_env.sh
@@ -4,7 +4,8 @@ export PLATFORM_GIT_BRANCH=master
 export PNDA_APPS_CONTAINER=pnda-apps
 export PNDA_APPS_FOLDER=releases
 export PNDA_ARCHIVE_CONTAINER=pnda-archive
-#export CLOUDERA_MIRROR
 export PACKAGES_SERVER_IP=x.x.x.x
+#export CLOUDERA_MIRROR=http://$PACKAGES_SERVER_IP/cloudera_repo
+#export ANACONDA_MIRROR=http://$PACKAGES_SERVER_IP/anaconda_repo
 export JAVA_MIRROR=http://$PACKAGES_SERVER_IP/components/java/jdk/8u74-b02/jdk-8u74-linux-x64.tar.gz
 export PACKAGES_SERVER_URI=http://$PACKAGES_SERVER_IP/packages


### PR DESCRIPTION
Allow the anaconda mirror to be overridden at provisioning time.
Mirroring repositories can help with reliability and download speeds.

PNDA-2060
