### PR TITLE
Reorganise cloud formation template

### DIFF
--- a/cloud-formation/standard/cf-tmpl.json
+++ b/cloud-formation/standard/cf-tmpl.json
@@ -1,5 +1,6 @@
 {
-  "Description" : "AWS CloudFormation Template for PNDA. Creates a VPC with Private and Public IP subnets, with access to most instances via a single public bastion node. Based in part on several sample templates provided by Amazon. Copyright (c) 2016 Cisco and/or its affiliates. This software is licensed to you under the terms of the Apache License, Version 2.0 (the \"License\"). You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0   The code, technical concepts, and all information contained herein, are the property of Cisco Technology, Inc.and/or its affiliated entities, under various laws including copyright, international treaties, patent, and/or contract. Any use of the material herein must be in accordance with the terms of the License. All rights not expressly granted by the License are reserved. Unless required by applicable law or agreed to separately in writing, software distributed under the License is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",    
+  "Description" : "AWS CloudFormation Template for PNDA. Creates a VPC with Private and Public IP subnets, with access to most instances via a single public bastion node.",  
+  "AWSTemplateFormatVersion": "2010-09-09",
   "Parameters" : {
     "pndaCluster" : {
       "Type" : "String",
@@ -104,7 +105,6 @@
       "Private"  : { "CIDR" : "10.0.1.0/24"}
     } 
   },  
-  "AWSTemplateFormatVersion": "2010-09-09",
   "Resources": {
     "VPC" : {
       "Type" : "AWS::EC2::VPC",
@@ -1224,6 +1224,5 @@
         "CidrIp": "0.0.0.0/0"
       }
     }
-  },
-  "Description": "pnda.pod"
+  }
 }


### PR DESCRIPTION
Move the version to the top and remove the license text that was
exceeding the 1024 character limit.
