### PR TITLE
Include cluster name in files used by the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.log
 *.pem
 *.pyc
+*.run
 hosts.txt
-cli/ssh_config
-cli/socks_proxy
+cli/ssh_config*
+cli/socks_proxy*
 client_env.sh
 pnda_env.sh
 *.tar.gz


### PR DESCRIPTION
Include the cluster name in the socks_proxy and ssh_config file names
so multiple clusters can be created at once from the same CLI directory.

PNDA-2333
