### PR TITLE
Log volume consistency changes

### DIFF
--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -13,13 +13,15 @@ apt-get update
 apt-get -y install xfsprogs
 
 # Mount the log volume, this is always xvdc
-echo "Mounting xvdc for logs"
-umount /dev/xvdc || echo 'not mounted'
-mkfs.xfs -f /dev/xvdc
-mkdir -p /var/log/panda
-sed -i "/xvdc/d" /etc/fstab
-echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
-
+if [ -b /dev/xvdc ];
+then
+   echo "Mounting xvdc for logs"
+   umount /dev/xvdc || echo 'not mounted'
+   mkfs.xfs -f /dev/xvdc
+   mkdir -p /var/log/panda
+   sed -i "/xvdc/d" /etc/fstab
+   echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
+fi
 # Mount the other log volumes if they exist, up to 3 more may be mounted but this list could be extended if required
 DISKS="xvdd xvde xvdf"
 DISK_IDX=0

--- a/bootstrap-scripts/pico/cdh-edge.sh
+++ b/bootstrap-scripts/pico/cdh-edge.sh
@@ -21,12 +21,15 @@ apt-get update
 apt-get -y install xfsprogs
 
 # Mount the log volume this is always xvdc
-echo "Mounting xvdc for logs"
-umount /dev/xvdc || echo 'not mounted'
-mkfs.xfs -f /dev/xvdc
-mkdir -p /var/log/panda
-sed -i "/xvdc/d" /etc/fstab
-echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
+if [ -b /dev/xvdc ];
+then
+  echo "Mounting xvdc for logs"
+  umount /dev/xvdc || echo 'not mounted'
+  mkfs.xfs -f /dev/xvdc
+  mkdir -p /var/log/panda
+  sed -i "/xvdc/d" /etc/fstab
+  echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
+fi
 
 # Mount the other log volumes if they exist, up to 3 more may be mounted but this list could be extended if required
 DISKS="xvdd xvde xvdf"

--- a/bootstrap-scripts/saltmaster.sh
+++ b/bootstrap-scripts/saltmaster.sh
@@ -21,12 +21,15 @@ apt-get update
 apt-get -y install xfsprogs
 
 # Mount the log volume this is always xvdc
-echo "Mounting xvdc for logs"
-umount /dev/xvdc || echo 'not mounted'
-mkfs.xfs -f /dev/xvdc
-mkdir -p /var/log/panda
-sed -i "/xvdc/d" /etc/fstab
-echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
+if [ -b /dev/xvdc ];
+then
+  echo "Mounting xvdc for logs"
+  umount /dev/xvdc || echo 'not mounted'
+  mkfs.xfs -f /dev/xvdc
+  mkdir -p /var/log/panda
+  sed -i "/xvdc/d" /etc/fstab
+  echo "/dev/xvdc /var/log/panda auto defaults,nobootwait,comment=cloudconfig 0 2" >> /etc/fstab
+fi
 
 # Mount the other log volumes if they exist, up to 3 more may be mounted but this list could be extended if required
 DISKS="xvdd xvde xvdf"

--- a/cloud-formation/cf-common.json
+++ b/cloud-formation/cf-common.json
@@ -29,7 +29,7 @@
     },
     "logVolumeSizeGb" : {
       "Type" : "String",
-      "Default" : "10",
+      "Default" : "120",
       "Description" : "Size in GB for the log volume"
     },
     "vpcCidr" : {

--- a/cloud-formation/pico/cf-flavor.json
+++ b/cloud-formation/pico/cf-flavor.json
@@ -27,7 +27,7 @@
     },
     "logVolumeSizeGb" : {
       "Type" : "String",
-      "Default" : "1",
+      "Default" : "10",
       "Description" : "Size in GB for the log volume"
     }    
   },
@@ -63,11 +63,7 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "20" }
-          },
-          {
-              "DeviceName" : "/dev/sdc",
-              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
-          }        
+          }       
         ],
         "NetworkInterfaces": [
           {

--- a/cloud-formation/standard/cf-flavor.json
+++ b/cloud-formation/standard/cf-flavor.json
@@ -101,11 +101,7 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },
-          {
-              "DeviceName" : "/dev/sdc",
-              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
-          }        
+          }       
         ],
         "NetworkInterfaces": [
           {
@@ -150,11 +146,11 @@
         "BlockDeviceMappings" : [
           {
               "DeviceName" : "/dev/sda1",
-              "Ebs" : { "VolumeSize" : "500" }
+              "Ebs" : { "VolumeSize" : "250" }
           },
           {
               "DeviceName" : "/dev/sdc",
-              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
+              "Ebs" : { "VolumeSize" : "250" }
           }        
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
@@ -193,15 +189,11 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
           },
           {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
-          }          
+              "DeviceName" : "/dev/sdc",
+              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
+          }         
         ],       
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
       }
@@ -238,13 +230,17 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
+          },
           {
-              "DeviceName"  : "/dev/sdc",
+              "DeviceName" : "/dev/sdc",
+              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
+          },                  
+          {
+              "DeviceName"  : "/dev/sdd",
               "VirtualName" : "ephemeral0"
           },
           {
-              "DeviceName"  : "/dev/sdd",
+              "DeviceName"  : "/dev/sde",
               "VirtualName" : "ephemeral1"
           }          
         ],
@@ -283,14 +279,6 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
-          },
-          {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
           }          
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
@@ -328,15 +316,7 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
-          },
-          {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
-          }          
+          }         
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
       }
@@ -419,14 +399,10 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
           },
           {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
+              "DeviceName" : "/dev/sdc",
+              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
           }          
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
@@ -505,14 +481,10 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
           },
           {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
+              "DeviceName" : "/dev/sdc",
+              "Ebs" : { "VolumeSize" : {"Ref": "logVolumeSizeGb"} }
           }          
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]
@@ -550,14 +522,6 @@
           {
               "DeviceName" : "/dev/sda1",
               "Ebs" : { "VolumeSize" : "50" }
-          },         
-          {
-              "DeviceName"  : "/dev/sdc",
-              "VirtualName" : "ephemeral0"
-          },
-          {
-              "DeviceName"  : "/dev/sdd",
-              "VirtualName" : "ephemeral1"
           }          
         ],
         "SecurityGroupIds": [ {"Ref": "pndaSg"} ]


### PR DESCRIPTION
Remove log volumes from instances that don't need them.
Use EBS for all other log volumes.
Reduce the log volume size for standard flavor from 250 to 120GB.
Reduce the logserver main volume for standard flavor from 500 to 250GB.
Increase the log volume size for pico from 1GB to 10GB.

PNDA-2340