### PR TITLE
CLI detects salt errors

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -174,7 +174,7 @@ def ssh(cmds, cluster, host):
     parts = cmd.split(' ')
     parts.append(';'.join(cmds))
     CONSOLE.debug(json.dumps(parts))
-    ret_val = subprocess_to_log.call(parts, LOG, host, scan_for_errors=['lost connection'])
+    ret_val = subprocess_to_log.call(parts, LOG, host, scan_for_errors=[r'lost connection', r'\s*Failed:\s*[1-9].*'])
     if ret_val != 0:
         raise Exception("Error running ssh commands on host %s. See debug log (%s) for details." % (host, LOG_FILE_NAME))
 
@@ -748,5 +748,4 @@ if __name__ == "__main__":
         main()
     except Exception as exception:
         CONSOLE.error(exception)
-        CONSOLE.error(traceback.format_exc())
         raise

--- a/cli/subprocess_to_log.py
+++ b/cli/subprocess_to_log.py
@@ -1,5 +1,6 @@
 import subprocess
 import select
+import re
 from logging import INFO
 
 
@@ -20,8 +21,9 @@ def call(cmd_to_run, logger, log_id=None, stdout_log_level=INFO, stderr_log_leve
             if log_id is not None:
                 msg_with_id = '%s %s' % (log_id, msg)
             logger.log(log_level[child_output_stream], msg_with_id)
-            if msg in scan_for_errors:
-                raise Exception(msg_with_id)
+            for pattern in scan_for_errors:
+                if re.match(pattern, msg):
+                    raise Exception(msg_with_id)
 
     while child_process.poll() is None:
         fetch_child_output()


### PR DESCRIPTION
CLI looks for salt output like "Failed: >0" and halts execution if
found.

PNDA-2043