### PR TITLE
Allow offline installation of ubuntu packages

### DIFF
--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -9,6 +9,15 @@
 
 set -e
 
+# If system packages are being installed from an offline bundle then download
+# that bundle and make the packages available for installation
+if [ "x$OS_PACKAGE_MIRROR" != "x" ] ; then
+wget ${OS_PACKAGE_MIRROR%/*}/apt-offline.deb
+dpkg -i apt-offline.deb
+wget $OS_PACKAGE_MIRROR
+apt-offline install ${OS_PACKAGE_MIRROR##*/}
+fi
+
 apt-get update
 apt-get -y install xfsprogs
 

--- a/bootstrap-scripts/pico/cdh-edge.sh
+++ b/bootstrap-scripts/pico/cdh-edge.sh
@@ -9,6 +9,15 @@
 # variables
 set -ex
 
+# If system packages are being installed from an offline bundle then download
+# that bundle and make the packages available for installation
+if [ "x$OS_PACKAGE_MIRROR" != "x" ] ; then
+wget ${OS_PACKAGE_MIRROR%/*}/apt-offline.deb
+dpkg -i apt-offline.deb
+wget $OS_PACKAGE_MIRROR
+apt-offline install ${OS_PACKAGE_MIRROR##*/}
+fi
+
 # Set up ssh access to the platform-salt git repo on the package server,
 # if secure access is required this key will be used automatically.
 # This mode is not normally used now the public github is available

--- a/bootstrap-scripts/saltmaster.sh
+++ b/bootstrap-scripts/saltmaster.sh
@@ -9,6 +9,15 @@
 # variables
 set -ex
 
+# If system packages are being installed from an offline bundle then download
+# that bundle and make the packages available for installation
+if [ "x$OS_PACKAGE_MIRROR" != "x" ] ; then
+wget ${OS_PACKAGE_MIRROR%/*}/apt-offline.deb
+dpkg -i apt-offline.deb
+wget $OS_PACKAGE_MIRROR
+apt-offline install ${OS_PACKAGE_MIRROR##*/}
+fi
+
 # Set up ssh access to the platform-salt git repo on the package server,
 # if secure access is required this key will be used automatically.
 # This mode is not normally used now the public github is available

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -89,6 +89,7 @@ mirrors:
   # These mirrors are optional and may be hosted on any HTTP server, including the PNDA component package server
   # CLOUDERA_MIRROR: http://x.x.x.x/cloudera_repo
   # ANACONDA_MIRROR: http://x.x.x.x/anaconda_repo
+  # OS_PACKAGE_MIRROR: http://x.x.x.x/components/deb-pkg/pnda-debs.zip
 
   # These mirrors are mandatory and may be hosted on any HTTP server, including the PNDA component package server
   JAVA_MIRROR: http://x.x.x.x/components/java/jdk/8u74-b02/jdk-8u74-linux-x64.tar.gz


### PR DESCRIPTION
Added the OS_PACKAGE_MIRROR setting to allow operating system packages
to be installed without internet access.

PNDA-2571