### PR TITLE
Wait for instance connectivity in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 ### Added
 - PNDA-2676: Support for redhat 7 in the bootstrap scripts. To use redhat set `OS_USER` to `ec2_user` and `imageId` to a redhat 7 AMI in pnda_env.yaml.
+- PNDA-2776. Wait on connectivity to cloud instances before trying to use them.
+- Removed support for key based login to git server hosting platform-salt.
 
 ## [1.2.0] 2017-01-20
 ### Fixed

--- a/bootstrap-scripts/pico/cdh-edge.sh
+++ b/bootstrap-scripts/pico/cdh-edge.sh
@@ -11,14 +11,6 @@ set -ex
 
 DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
 
-# Set up ssh access to the platform-salt git repo on the package server,
-# if secure access is required this key will be used automatically.
-# This mode is not normally used now the public github is available
-chmod 400 /tmp/git.pem
-echo "Host $PACKAGES_SERVER_IP" >> /root/.ssh/config
-echo "  IdentityFile /tmp/git.pem" >> /root/.ssh/config
-echo "  StrictHostKeyChecking no" >> /root/.ssh/config
-
 # Install a saltmaster and minion, plus saltmaster config
 if [ "x$DISTRO" == "xubuntu" ]; then
 export DEBIAN_FRONTEND=noninteractive

--- a/bootstrap-scripts/saltmaster.sh
+++ b/bootstrap-scripts/saltmaster.sh
@@ -11,14 +11,6 @@ set -ex
 
 DISTRO=$(cat /etc/*-release|grep ^ID\=|awk -F\= {'print $2'}|sed s/\"//g)
 
-# Set up ssh access to the platform-salt git repo on the package server,
-# if secure access is required this key will be used automatically.
-# This mode is not normally used now the public github is available
-chmod 400 /tmp/git.pem
-echo "Host $PACKAGES_SERVER_IP" >> /root/.ssh/config
-echo "  IdentityFile /tmp/git.pem" >> /root/.ssh/config
-echo "  StrictHostKeyChecking no" >> /root/.ssh/config
-
 # Install a saltmaster, plus saltmaster config
 if [ "x$DISTRO" == "xubuntu" ]; then
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
The CLI used to assume instances would be ready for SSH access as soon
as the cloud formation stack was reported as CREATED. This was not
always the case depending on AWS region used. Now the CLI checks
connectivity to each instance in turn before continuing.

PNDA-2776