### PR TITLE
Sync grains manually before running salt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+- PNDA-2851: manually sync grains before running salt commands as sometimes the ec2 grain wasn't available yet when running highstate.
+
 ### Changed
 - PNDA-2809: Update m3 instance type defaults to use the latest m4 family instead.
 

--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -418,7 +418,8 @@ def create(template_data, cluster, flavor, keyname, no_config_check, branch):
     time.sleep(30)
     CONSOLE.info('Running salt to install software. Expect this to take 45 minutes or more, check the debug log for progress (%s).', LOG_FILE_NAME)
     bastion = NODE_CONFIG['bastion-instance']
-    ssh(['(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
+    ssh(['sudo salt "*" saltutil.sync_all',
+         '(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
          '(sudo CLUSTER=%s salt-run --log-level=debug state.orchestrate orchestrate.pnda 2>&1) | tee -a pnda-salt.log; %s' % (cluster, THROW_BASH_ERROR),
          '(sudo salt "*-%s" state.sls hostsfile 2>&1) | tee -a pnda-salt.log; %s' % (bastion, THROW_BASH_ERROR)],
         cluster, saltmaster['private_ip_address'])
@@ -481,7 +482,8 @@ def expand(template_data, cluster, flavor, old_datanodes, old_kafka, keyname, br
     time.sleep(30)
 
     CONSOLE.info('Running salt to install software. Expect this to take 10 - 20 minutes, check the debug log for progress. (%s)', LOG_FILE_NAME)
-    ssh(['(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
+    ssh(['sudo salt "*" saltutil.sync_all',
+         '(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
          '(sudo CLUSTER=%s salt-run --log-level=debug state.orchestrate orchestrate.pnda-expand 2>&1) | tee -a pnda-salt.log; %s' % (cluster, THROW_BASH_ERROR),
          '(sudo salt "*-%s" state.sls hostsfile 2>&1) | tee -a pnda-salt.log; %s' % (bastion, THROW_BASH_ERROR)],
         cluster, saltmaster)


### PR DESCRIPTION
Added an explicit saltulti.sync_all for all minions to try to fix the
problem where ec2 grains are sometimes not available when running salt
for the first time.

PNDA-2851