### PR TITLE
Move yum repo defs to a backup folder

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -13,7 +13,8 @@ if [ "x$DISTRO" == "xubuntu" ]; then
   apt-get update
 
 elif [ "x$DISTRO" == "xrhel" ]; then
-
+mkdir -p /etc/yum.repos.d.backup/
+mv /etc/yum.repos.d/* /etc/yum.repos.d.backup/
 yum-config-manager --add-repo $PNDA_MIRROR/mirror_rpm
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-redhat-release
 rpm --import $PNDA_MIRROR/mirror_rpm/RPM-GPG-KEY-mysql


### PR DESCRIPTION
To make sure that only the PNDA mirror is used during setup we now move
the repo defs to another folder.

PNDA-2987