### PR TITLE
Remove EPEL from set of standard online repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`
+- PNDA-3215: Remove EPEL repository
 
 ## [1.3.0] 2017-08-01
 ### Added

--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -17,8 +17,6 @@ elif [ "x$DISTRO" == "xrhel" ]; then
 if [ "x$YUM_OFFLINE" == "x" ]; then
 RPM_EXTRAS=rhui-REGION-rhel-server-extras
 RPM_OPTIONAL=rhui-REGION-rhel-server-optional
-RPM_EPEL=https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-yum install -y $RPM_EPEL
 yum-config-manager --enable $RPM_EXTRAS $RPM_OPTIONAL
 yum install -y yum-plugin-priorities yum-utils 
 PNDA_REPO=${PNDA_MIRROR/http\:\/\//}


### PR DESCRIPTION
The EPEL repository is not a part of Red Hat Enterprise Linux, although
we install some packages from this repository these are installed via
the PNDA mirror. A user would not necessarily expect to have this
repository included by default.

It is also seen to be by far the most unreliable repo, causing repeated
failures in provisioning.

PNDA-3215