### PR TITLE
Only perform strictly required steps on specific nodes during cluster expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`
 - PNDA-3215: Remove EPEL repository
+- PNDA-3180: When expanding a cluster limit the operations to strictly required steps on specific nodes
 
 ## [1.3.0] 2017-08-01
 ### Added

--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -56,6 +56,7 @@ EOF
 cat >> /etc/salt/grains <<EOF
 pnda:
   flavor: $PNDA_FLAVOR
+  is_new_node: True
 
 pnda_cluster: $PNDA_CLUSTER 
 EOF

--- a/bootstrap-scripts/pico/hadoop-edge.sh
+++ b/bootstrap-scripts/pico/hadoop-edge.sh
@@ -18,9 +18,7 @@ service salt-master restart
 # place specific hadoop roles on this instance.
 # The mapping of hadoop roles to hadoop:role grains is
 # defined in the cfg_<flavor>.py.tpl files (in platform-salt)
-cat > /etc/salt/grains <<EOF
-pnda:
-  flavor: $PNDA_FLAVOR
+cat >> /etc/salt/grains <<EOF
 hadoop:
   role: EDGE
 roles:
@@ -46,8 +44,6 @@ roles:
   - hdfs_cleaner
   - master_dataset
   - pnda_restart
-
-pnda_cluster: $PNDA_CLUSTER
 EOF
 
 cat >> /etc/salt/minion <<EOF

--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -450,7 +450,7 @@ def create(template_data, cluster, flavor, keyname, no_config_check, dry_run, br
          '(sudo salt "*-%s" state.sls hostsfile 2>&1) | tee -a pnda-salt.log; %s' % (bastion, THROW_BASH_ERROR)], cluster, saltmaster_ip)
     return instance_map[cluster + '-' + NODE_CONFIG['console-instance']]['private_ip_address']
 
-def expand(template_data, cluster, flavor, old_datanodes, old_kafka, keyname, no_config_check, dry_run, branch):
+def expand(template_data, cluster, flavor, old_datanodes, old_kafka, include_orchestrate, keyname, no_config_check, dry_run, branch):
     keyfile = '%s.pem' % keyname
 
     if not no_config_check:
@@ -516,9 +516,17 @@ def expand(template_data, cluster, flavor, old_datanodes, old_kafka, keyname, no
     time.sleep(30)
 
     CONSOLE.info('Running salt to install software. Expect this to take 10 - 20 minutes, check the debug log for progress. (%s)', LOG_FILE_NAME)
-    ssh(['(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.highstate 2>&1) | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
-         '(sudo CLUSTER=%s salt-run --log-level=debug state.orchestrate orchestrate.pnda-expand 2>&1) | tee -a pnda-salt.log; %s' % (cluster, THROW_BASH_ERROR),
-         '(sudo salt "*-%s" state.sls hostsfile 2>&1) | tee -a pnda-salt.log; %s' % (bastion, THROW_BASH_ERROR)], cluster, saltmaster_ip)
+    expand_commands = ['(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed "*" state.sls hostsfile 2>&1)' +
+                       ' | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR,
+                       '(sudo salt -v --log-level=debug --timeout=120 --state-output=mixed -C "G@pnda:is_new_node" state.highstate 2>&1)' +
+                       ' | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR]
+    if include_orchestrate:
+        CONSOLE.info('Including orchestrate because new Hadoop datanodes are being added')
+        expand_commands.append('(sudo CLUSTER=%s salt-run --log-level=debug state.orchestrate orchestrate.pnda-expand 2>&1)' % cluster +
+                               ' | tee -a pnda-salt.log; %s' % THROW_BASH_ERROR)
+
+    ssh(expand_commands, cluster, saltmaster_ip)
+
     return instance_map[cluster + '-' + NODE_CONFIG['console-instance']]['private_ip_address']
 
 def destroy(cluster):
@@ -627,8 +635,8 @@ def get_args():
     parser.add_argument('-b', '--branch', help='Branch of platform-salt to use. Overrides value in pnda_env.yaml')
     parser.add_argument('-d', '--dry-run', action='store_true',
                         help='Output the final Cloud Formation template but do not apply it. ' +
-                             'Useful for checking against the existing Cloud formation template to' +
-                             'gain confidence before running the expand operation.')
+                        'Useful for checking against the existing Cloud formation template to' +
+                        'gain confidence before running the expand operation.')
 
     args = parser.parse_args()
     return args
@@ -725,6 +733,8 @@ def main():
     NODE_CONFIG = json.load(node_config_file)
     node_config_file.close()
 
+    include_orchestrate = False
+
     if args.command == 'expand':
         if pnda_cluster is not None:
             node_counts = get_current_node_counts(pnda_cluster)
@@ -746,6 +756,7 @@ def main():
                 sys.exit(1)
             elif datanodes > node_counts['hadoop-dn']:
                 print "Increasing the number of datanodes from %s to %s" % (node_counts['hadoop-dn'], datanodes)
+                include_orchestrate = True
             if kafkanodes < node_counts['kafka']:
                 print "You cannot shrink the cluster using this CLI, existing number of kafkanodes is: %s" % node_counts['kafka']
                 sys.exit(1)
@@ -755,7 +766,8 @@ def main():
             template_data = generate_template_file(flavor, datanodes, node_counts['opentsdb'], kafkanodes, node_counts['zk'],
                                                    es_master_nodes, es_ingest_nodes, es_data_nodes, es_coordinator_nodes,
                                                    es_multi_nodes, logstash_nodes)
-            expand(template_data, pnda_cluster, flavor, node_counts['hadoop-dn'], node_counts['kafka'], keyname, no_config_check, dry_run, branch)
+            expand(template_data, pnda_cluster, flavor, node_counts['hadoop-dn'], node_counts['kafka'],
+                   include_orchestrate, keyname, no_config_check, dry_run, branch)
             sys.exit(0)
         else:
             print 'expand command must specify pnda_cluster, e.g.\npnda-cli.py expand -e squirrel-land -f standard -s keyname -n 5'


### PR DESCRIPTION
Run hostsfile sls instead of highstate cluster-wide for expand operation
Add is_new_node grain to mark new nodes and limit orchestrate command to new nodes
Only include orchestrate stage when adding new datanodes

PNDA-3180