### PR TITLE
saltIssue293:OpenTsdb service not running after deployment

### DIFF
--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -52,9 +52,13 @@ mount -a
 # Set the master address the minion will register itself with
 cat > /etc/salt/minion <<EOF
 master: $PNDA_SALTMASTER_IP
+EOF
+
+cat >> /etc/salt/minion.d/beacons.conf <<EOF
 beacons:
   kernel_reboot_required:
     interval: $PLATFORM_SALT_BEACON_TIMEOUT
+    disable_during_state_run: True
 EOF
 
 # Set the grains common to all minions

--- a/bootstrap-scripts/hadoop-cm.sh
+++ b/bootstrap-scripts/hadoop-cm.sh
@@ -27,7 +27,8 @@ EOF
 
 cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-hadoop-cm
-beacons:
+EOF
+cat >> /etc/salt/minion.d/beacons.conf <<EOF
   service_restart:
     interval: $PLATFORM_SALT_BEACON_TIMEOUT
     disable_during_state_run: True

--- a/bootstrap-scripts/opentsdb.sh
+++ b/bootstrap-scripts/opentsdb.sh
@@ -28,6 +28,11 @@ cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-opentsdb-$1
 EOF
 
+cat >> /etc/salt/minion.d/beacons.conf <<EOF
+  service_opentsdb:
+    interval: $PLATFORM_SALT_BEACON_TIMEOUT
+    disable_during_state_run: True
+EOF
 echo $PNDA_CLUSTER-opentsdb-$1 > /etc/hostname
 hostname $PNDA_CLUSTER-opentsdb-$1
 

--- a/bootstrap-scripts/pico/hadoop-edge.sh
+++ b/bootstrap-scripts/pico/hadoop-edge.sh
@@ -48,7 +48,9 @@ EOF
 
 cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-hadoop-edge
-beacons:
+EOF
+
+cat >> /etc/salt/minion.d/beacons.conf <<EOF
   service_restart:
     interval: $PLATFORM_SALT_BEACON_TIMEOUT
     disable_during_state_run: True

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -56,7 +56,8 @@ reactor:
     - salt://reactor/delete_bastion_host_entry.sls
   - 'salt/beacon/*/kernel_reboot_required/*/reboot-required':
     - salt://reactor/kernel_reboot_entry.sls
-
+  - 'salt/beacon/*/service_opentsdb/service/opentsdb/status/stop/HBaseUp':
+    - salt://reactor/service_opentsdb_entry.sls
 ## end of specific PNDA saltmaster config
 file_recv: True
 

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -48,11 +48,10 @@ platform_salt:
 
   # Local path to folder containing a clone of the platform salt repository
   # PLATFORM_SALT_LOCAL: /path/to/platform-salt
-  # Beacon timeout to check system reboot 
-  PLATFORM_SALT_BEACON_TIMEOUT: 30
 
   # Beacon timeout to check system reboot 
   PLATFORM_SALT_BEACON_TIMEOUT: 30
+
 
 pnda_application_repo:
   # Type of storage to use for PNDA application packages


### PR DESCRIPTION
Problem Statement:
OpenTsdb service is not running after deployment

Analysis:
1. OpenTsdb service needs HBase service
2. if openTsdb started before HBase , it will down
3. PNDA-2389 restart the nodes after deployment, this cause the order of service placement
4. Need to start the OpenTsdb again after HBase is up

Change:

1. implement the Beacon and reactor method to implement fix
2. implement beacon only in OpenTsdb node only 
3. Check the Opentsdb status and Hbase status <ambari or cludera>
4. if OpenTsdb is Down and Habse is up, send the following tag to reactor 
+  - 'salt/beacon/*/service_opentsdb/service/opentsdb/status/stop/HBaseUp':
5. reactor will start the service again


Test details:
1. Need to test  all 16<2^4> combinations (OS,AWS),(HDP,CDH),(pico,standard),(redhat,ubuntu)
2. tested in AWS , testing pending in  Openstack.
3. Now opentsdb running after deployment.
4. stopped opentsdb nodes , and it's comes up automatically