### PR TITLE
PNDA 2390: PNDA restarts any services that need restarting when rebooted

### DIFF
--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -58,6 +58,8 @@ reactor:
     - salt://reactor/kernel_reboot_entry.sls
   - 'salt/beacon/*/service_opentsdb/service/opentsdb/status/stop/HBaseUp':
     - salt://reactor/service_opentsdb_entry.sls
+  - 'salt/beacon/*/service_restart/service/hadoop/status/stopped':
+    - salt://reactor/service_hadoop_start_entry.sls
 ## end of specific PNDA saltmaster config
 file_recv: True
 


### PR DESCRIPTION
**# Problem Statement:**
PNDA 2390: NDA restarts any services that need restarting when rebooted

**# Analysis:**
   Hadoop services are down due to node reboot or other issues
   Services once down needs user intervention to start services
   Need to automate the start process
**# Change:**
   Fix supports for Ambari (HDP distribution)
   implement the Beacon and reactor method to implement the fix
   
   **BEACON:**
   Beacon verify the current status using REST API <http://10.0.1.246:8080/api/v1/clusters/jana/>
   Verify the health report and if any node down, starts the service
   
   **REACTOR:**
   verify the retry count, if its less then 3 start the process
   print name of the services changed the state with a host name
   
   
**# Test details:**
   
   Verified  the fix for AWS:
   1. UBUNTU - PICO -HDP
   2. UBUNTU - STD -HDP
   3. RHEL - PICO -HDP
   3. RHEL - STD -HDP 
   
  **Verification pending for OpenStack**
  **CDH testing not required, Fix applicable for HDP.**
  
  