### PR TITLE
Reuses existing ssh-agent in socks_proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - PNDA-3215: Remove EPEL repository
 - PNDA-3180: When expanding a cluster limit the operations to strictly required steps on specific nodes
 
+### Fixed
+- PNDA-3200: socks_proxy script reuses existing ssh-agent instead of launching a new one if possible
+
 ## [1.3.0] 2017-08-01
 ### Added
 - PNDA-2375: Isolate PNDA from breaking dependency change

--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -318,6 +318,33 @@ def write_ssh_config(cluster, bastion_ip, os_user, keyfile):
                           % (keyfile, os_user, bastion_ip))
 
     with open('cli/socks_proxy-%s' % cluster, 'w') as config_file:
+        config_file.write('''
+unset SSH_AUTH_SOCK
+unset SSH_AGENT_PID
+
+for FILE in $(find /tmp/ssh-* -type s -user ${LOGNAME} -name "agent.[0-9]*" 2>/dev/null)
+do
+    SOCK_PID=${FILE##*.}
+
+    PID=$(ps -fu${LOGNAME}|awk '/ssh-agent/ && ( $2=='${SOCK_PID}' || $3=='${SOCK_PID}' || $2=='${SOCK_PID}' +1 ) {print $2}')
+
+    if [ -z "$PID" ]
+    then
+        continue
+    fi
+
+    export SSH_AUTH_SOCK=${FILE}
+    export SSH_AGENT_PID=${PID}
+    break
+done
+
+if [ -z "$SSH_AGENT_PID" ]
+then
+    echo "Starting a new SSH Agent..."
+    eval `ssh-agent`
+else
+    echo "Using existing SSH Agent with pid: ${SSH_AGENT_PID}, sock file: ${SSH_AUTH_SOCK}"
+fi\n''')
         config_file.write('eval `ssh-agent`\n')
         config_file.write('ssh-add %s\n' % keyfile)
         config_file.write('ssh -i %s -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -A -D 9999 %s@%s\n' % (keyfile, os_user, bastion_ip))


### PR DESCRIPTION
socks_proxy script reuses existing ssh-agent instead of launching a new
one if possible

PNDA-3200