### PR TITLE
Fix issue with multiple NICs on same network

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -338,7 +338,7 @@ def wait_for_host_connectivity(hosts, cluster):
             except:
                 CONSOLE.info('Still waiting for connectivity to %s. See debug log (%s) for details.', host, LOG_FILE_NAME)
                 LOG.info(traceback.format_exc())
-                if MILLI_TIME() - time_start > 5 * 60 * 1000:
+                if MILLI_TIME() - time_start > 10 * 60 * 1000:
                     CONSOLE.error('Giving up waiting for host connectivity')
                     sys.exit(-1)
                 time.sleep(2)
@@ -355,7 +355,8 @@ def create(template_data, cluster, flavor, keyname, no_config_check, dry_run, br
     keyfile = '%s.pem' % keyname
 
     region = PNDA_ENV['ec2_access']['AWS_REGION']
-    cf_parameters = [('keyName', keyname), ('pndaCluster', cluster)]
+    awsAvailabilityZone = PNDA_ENV['ec2_access']['AWS_AVAILABILITY_ZONE']
+    cf_parameters = [('keyName', keyname), ('pndaCluster', cluster), ('awsAvailabilityZone', awsAvailabilityZone)]
     for parameter in PNDA_ENV['cloud_formation_parameters']:
         cf_parameters.append((parameter, PNDA_ENV['cloud_formation_parameters'][parameter]))
 

--- a/cloud-formation/cf-common.json
+++ b/cloud-formation/cf-common.json
@@ -7,10 +7,20 @@
       "Default" : "pnda",
       "Description" : "Name for this cluster"
     },
+    "awsAvailabilityZone" : {
+      "Type" : "String",
+      "Default" : "eu-west-1a",
+      "Description" : "Availability Zone for subnet"
+    },
     "whitelistSshAccess" : {
       "Type" : "String",
       "Default" : "0.0.0.0/0",
       "Description" : "Whitelist for external access to ssh"
+    },
+    "whitelistKafkaAccess" : {
+      "Type" : "String",
+      "Default" : "0.0.0.0/0",
+      "Description" : "Whitelist for external access to Kafka"
     },
     "imageId" : {
       "Type" : "String",
@@ -46,6 +56,11 @@
       "Type" : "String",
       "Default" : "10.0.1.0/24",
       "Description" : "CIDR specifying the address range for the private subnet"
+    },
+    "publicProducerSubnetCidr" : {
+      "Type" : "String",
+      "Default" : "10.0.2.0/24",
+      "Description" : "CIDR specifying the address range for the public subnet for producers"
     }
   },
   "Resources": {
@@ -67,6 +82,7 @@
       "Properties" : {
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Ref" : "publicSubnetCidr" },
+        "AvailabilityZone" : {"Ref": "awsAvailabilityZone"},
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackName" } },
           { "Key" : "Network", "Value" : "Public" }
@@ -132,6 +148,43 @@
       }
     },
 
+    "PublicProducerNetworkAcl" : {
+      "Type" : "AWS::EC2::NetworkAcl",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackName" } },
+          { "Key" : "Network", "Value" : "PublicProducer" }
+        ]
+      }
+    },
+
+    "InboundProducerSSHPublicNetworkAclEntry" : {
+      "Type" : "AWS::EC2::NetworkAclEntry",
+      "Properties" : {
+        "NetworkAclId" : { "Ref" : "PublicProducerNetworkAcl" },
+        "RuleNumber" : "101",
+        "Protocol" : "6",
+        "RuleAction" : "allow",
+        "Egress" : "false",
+        "CidrBlock" : "0.0.0.0/0",
+        "PortRange" : { "From" : "22", "To" : "22" }
+      }
+    },
+    
+    "InboundKafkaPublicNetworkAclEntry" : {
+      "Type" : "AWS::EC2::NetworkAclEntry",
+      "Properties" : {
+        "NetworkAclId" : { "Ref" : "PublicProducerNetworkAcl" },
+        "RuleNumber" : "100",
+        "Protocol" : "6",
+        "RuleAction" : "allow",
+        "Egress" : "false",
+        "CidrBlock" : "0.0.0.0/0",
+        "PortRange" : { "From" : "9090", "To" : "9100" }
+      }
+    },
+    
     "InboundHTTPPublicNetworkAclEntry" : {
       "Type" : "AWS::EC2::NetworkAclEntry",
       "Properties" : {
@@ -210,6 +263,19 @@
       }
     },
 
+    "OutboundPublicProducerNetworkAclEntry" : {
+      "Type" : "AWS::EC2::NetworkAclEntry",
+      "Properties" : {
+        "NetworkAclId" : { "Ref" : "PublicProducerNetworkAcl" },
+        "RuleNumber" : "100",
+        "Protocol" : "6",
+        "RuleAction" : "allow",
+        "Egress" : "true",
+        "CidrBlock" : "0.0.0.0/0",
+        "PortRange" : { "From" : "0", "To" : "65535" }
+      }
+    },
+    
     "OutboundPublicNetworkAclEntry" : {
       "Type" : "AWS::EC2::NetworkAclEntry",
       "Properties" : {
@@ -249,6 +315,7 @@
       "Properties" : {
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Ref" : "privateSubnetCidr" },
+        "AvailabilityZone" : {"Ref": "awsAvailabilityZone"},
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackName" } },
           { "Key" : "Network", "Value" : "Private" }
@@ -269,6 +336,7 @@
         "Domain" : "vpc"
       }
     },
+
     "PrivateRouteTable" : {
       "Type" : "AWS::EC2::RouteTable",
       "Properties" : {
@@ -294,6 +362,74 @@
             "RouteTableId" : { "Ref" : "PrivateRouteTable" }
          }
     },
+
+     "PublicProducerSubnet" : {
+      "Type" : "AWS::EC2::Subnet",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "CidrBlock" : { "Ref" : "publicProducerSubnetCidr" },
+        "AvailabilityZone" : {"Ref": "awsAvailabilityZone"},
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackName" } },
+          { "Key" : "Network", "Value" : "Public" }
+        ]
+      }
+    },
+    
+    "PublicProducerRouteTable" : {
+      "Type" : "AWS::EC2::RouteTable",
+      "Properties" : {
+        "VpcId" : { "Ref" : "VPC" },
+        "Tags" : [
+          { "Key" : "Application", "Value" : { "Ref" : "AWS::StackName" } },
+          { "Key" : "Network", "Value" : "PublicProducer" }
+        ]
+      }
+    },
+    "PublicProducerRoute" : {
+      "Type" : "AWS::EC2::Route",
+      "Properties" : {
+        "RouteTableId" : { "Ref" : "PublicProducerRouteTable" },
+        "DestinationCidrBlock" : "0.0.0.0/0",
+        "GatewayId" : { "Ref" : "InternetGateway" }
+      }
+    },
+
+    "PublicProducerSubnetRouteTableAssociation" : {
+         "Type" : "AWS::EC2::SubnetRouteTableAssociation",
+         "Properties" : {
+            "SubnetId" : { "Ref" : "PublicProducerSubnet" },
+            "RouteTableId" : { "Ref" : "PublicProducerRouteTable" }
+         }
+    },
+
+    "PublicProducerSubnetNetworkAclAssociation" : {
+      "Type" : "AWS::EC2::SubnetNetworkAclAssociation",
+      "Properties" : {
+        "SubnetId" : { "Ref" : "PublicProducerSubnet" },
+        "NetworkAclId" : { "Ref" : "PublicProducerNetworkAcl" }
+      }
+    },
+    "kafkaSg": {
+      "Type": "AWS::EC2::SecurityGroup",
+      "Properties": {
+        "GroupDescription": "access to Kafka",
+        "VpcId": {"Ref": "VPC"}
+      }
+    },
+   "ingressKafka1": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "GroupId": {
+          "Ref": "kafkaSg"
+        },
+        "IpProtocol": "tcp",
+        "FromPort": "9090",
+        "ToPort": "9100",
+        "CidrIp": { "Ref" : "whitelistKafkaAccess" }
+      }
+    },
+    
     "sshSg": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {

--- a/cloud-formation/pico/cf-flavor.json
+++ b/cloud-formation/pico/cf-flavor.json
@@ -138,12 +138,30 @@
             "DeleteOnTermination": "true",
             "Description": "Secondary network interface",
             "DeviceIndex": 1,
-            "SubnetId": {"Ref": "PrivateSubnet"},
-            "GroupSet": [{"Ref": "pndaSg"}]
+            "SubnetId": {"Ref": "PublicProducerSubnet"},
+            "GroupSet": [{"Ref": "pndaSg"},{"Ref": "kafkaSg"}]
           }
-        ]
+        ],
+        "UserData" : { "Fn::Base64" : { "Fn::Join" : ["", [
+            "#!/bin/bash -v\n",
+            "cat > /etc/network/interfaces <<EOF\n",
+            "auto eth0\n",
+            "iface eth0 inet dhcp\n",
+            "post-up ip route add default via 10.0.1.1 dev eth0 tab 1\n",
+            "post-up ip rule add from 10.0.1.0/24 tab 1\n",
+            "auto eth1\n",
+            "iface eth1 inet dhcp\n",
+            "post-up ip route add default via 10.0.2.1 dev eth1 tab 2\n",
+            "post-up ip rule add from 10.0.2.0/24 tab 2\n",
+            "EOF\n",
+            "ifdown eth0\n",
+            "ifdown eth1\n",
+            "ifup eth0\n",
+            "ifup eth1\n"
+        ]]}}
       }
     },
+    
     "instanceCdhDn": {
       "Type": "AWS::EC2::Instance",
       "Properties": {

--- a/cloud-formation/standard/cf-flavor.json
+++ b/cloud-formation/standard/cf-flavor.json
@@ -285,7 +285,7 @@
             "DeleteOnTermination": "true",
             "Description": "Secondary network interface",
             "DeviceIndex": 1,
-            "SubnetId": {"Ref": "PrivateSubnet"},
+            "SubnetId": {"Ref": "PublicProducerSubnet"},
             "GroupSet": [{"Ref": "pndaSg"}]
           }
         ]

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -6,7 +6,8 @@ ec2_access:
 
   # AWS region to create PNDA ec2 instances in
   AWS_REGION: eu-west-1
-
+  AWS_AVAILABILITY_ZONE: eu-west-1a
+  
   # The user name to use when logging into the AWS ec2 instances
   # Ubuntu: ubuntu
   # Redhat: ec2-user


### PR DESCRIPTION
Fixes bug regarding clusters hanging after reboot by introducing a dedicated public network for Kafka ingest and explicitly defining routing for the Kafka instances that use it.

This is intended to fix the immediate issue of builds failing for Ubuntu - there is more more to do to make this as configurable as the other subnets, as well as additional stories to pre-configure public facing IPs via the new subnet.