### PR TITLE
PNDA 2390: PNDA restarts any services that need restarting when rebooted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-1960: Make Kafkat available on nodes as option for Kafka management at CLI
 - PNDA-2955: Add pnda_env.yaml setting for choosing hadoop distro to install
 - PNDA-2389: PNDA automatically reboots instances that need rebooting following kernel updates
+- PNDA 2390: PNDA restarts any services that need restarting when rebooted
 - PNDA-3302: upgrade edge flavor on pico
 - PNDA-3218: Add iprejecter to enable offline env
 

--- a/bootstrap-scripts/base.sh
+++ b/bootstrap-scripts/base.sh
@@ -54,13 +54,6 @@ cat > /etc/salt/minion <<EOF
 master: $PNDA_SALTMASTER_IP
 EOF
 
-cat >> /etc/salt/minion.d/beacons.conf <<EOF
-beacons:
-  kernel_reboot_required:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
-    disable_during_state_run: True
-EOF
-
 # Set the grains common to all minions
 cat >> /etc/salt/grains <<EOF
 pnda:

--- a/bootstrap-scripts/hadoop-cm.sh
+++ b/bootstrap-scripts/hadoop-cm.sh
@@ -28,11 +28,6 @@ EOF
 cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-hadoop-cm
 EOF
-cat >> /etc/salt/minion.d/beacons.conf <<EOF
-  service_restart:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
-    disable_during_state_run: True
-EOF
 
 echo $PNDA_CLUSTER-hadoop-cm > /etc/hostname
 hostname $PNDA_CLUSTER-hadoop-cm

--- a/bootstrap-scripts/opentsdb.sh
+++ b/bootstrap-scripts/opentsdb.sh
@@ -28,11 +28,6 @@ cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-opentsdb-$1
 EOF
 
-cat >> /etc/salt/minion.d/beacons.conf <<EOF
-  service_opentsdb:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
-    disable_during_state_run: True
-EOF
 echo $PNDA_CLUSTER-opentsdb-$1 > /etc/hostname
 hostname $PNDA_CLUSTER-opentsdb-$1
 

--- a/bootstrap-scripts/pico/hadoop-edge.sh
+++ b/bootstrap-scripts/pico/hadoop-edge.sh
@@ -50,10 +50,5 @@ cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-hadoop-edge
 EOF
 
-cat >> /etc/salt/minion.d/beacons.conf <<EOF
-  service_restart:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
-    disable_during_state_run: True
-EOF
 
 service salt-minion restart

--- a/bootstrap-scripts/pico/hadoop-mgr.sh
+++ b/bootstrap-scripts/pico/hadoop-mgr.sh
@@ -30,12 +30,6 @@ cat >> /etc/salt/minion <<EOF
 id: $PNDA_CLUSTER-hadoop-mgr-1
 EOF
 
-cat >> /etc/salt/minion.d/beacons.conf <<EOF
-  service_opentsdb:
-    interval: $PLATFORM_SALT_BEACON_TIMEOUT
-    disable_during_state_run: True
-EOF
-
 echo $PNDA_CLUSTER-hadoop-mgr-1 > /etc/hostname
 hostname $PNDA_CLUSTER-hadoop-mgr-1
 

--- a/bootstrap-scripts/saltmaster-common.sh
+++ b/bootstrap-scripts/saltmaster-common.sh
@@ -56,8 +56,13 @@ reactor:
     - salt://reactor/delete_bastion_host_entry.sls
   - 'salt/beacon/*/kernel_reboot_required/*/reboot-required':
     - salt://reactor/kernel_reboot_entry.sls
+  - 'salt/beacon/*/service_restart/service/hadoop/status/stopped':
+    - salt://reactor/service_hadoop_start_entry.sls
+  - 'salt/beacon/*/service_restart/service/hadoop/addon/status/stopped':
+    - salt://reactor/service_hadoop_addon_start_entry.sls
   - 'salt/beacon/*/service_opentsdb/service/opentsdb/status/stop/HBaseUp':
     - salt://reactor/service_opentsdb_entry.sls
+
 ## end of specific PNDA saltmaster config
 file_recv: True
 


### PR DESCRIPTION
**Problem Statement:**

PNDA 2390: PNDA restarts any services that need restarting when rebooted

**Analysis:**

Hadoop services are down due to node reboot or other issues
Services once down needs user intervention to start services
Need to automate the start process

**Change**:

Fix supports for Ambari (HDP distribution)
implemented the Beacon and reactor method to implement the fix

**Files Changed:**

 Removed Beacon entry from bootstrap script and moved to platform-salt 
 1. bootstrap-scripts/base.sh
 2. bootstrap-scripts/hadoop-cm.sh
 3. bootstrap-scripts/opentsdb.sh
 4. bootstrap-scripts/pico/hadoop-edge.sh
 5. bootstrap-scripts/pico/hadoop-mgr.sh
 
 Added the reactor entry to start HDP servie and HDP addon service 
 1. bootstrap-scripts/saltmaster-common.sh