### PR TITLE
Disallow uppercase letters in the cluster names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - PNDA-3218: Add iprejecter to enable offline env
 
 ### Changed
+- PNDA-3444: Disallow uppercase letters in the cluster names.
 - PNDA-2965: Rename `cloudera_*` role grains to `hadoop_*`
 - PNDA-3215: Remove EPEL repository
 - PNDA-3180: When expanding a cluster limit the operations to strictly required steps on specific nodes

--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -55,7 +55,7 @@ CONSOLE = logging.getLogger('console')
 CONSOLE.addHandler(logging.StreamHandler())
 CONSOLE.handlers[0].setFormatter(LOG_FORMATTER)
 
-NAME_REGEX = r"^[\.a-zA-Z0-9-]+$"
+NAME_REGEX = r"^[\.a-z0-9-]+$"
 VALIDATION_RULES = None
 NODE_CONFIG = None
 PNDA_ENV = None


### PR DESCRIPTION
PNDA-3444:
Uppercase characters in the cluster name causes issues with HDP.
This is due to a know bug in ambari that has been reported:
https://issues.apache.org/jira/browse/AMBARI-22361
and needs to be tracked to remove this patch over time.
The issue in HDP is with the usage of upper case in the hostnames which
get assigned based in the cluster name. As such, the work around here
will prevent the usage up uppercase in the cluster name until we can
move to a version of HDP that contains a fix for the bug reported
above.