### PR TITLE
Issue 121: SALTSTACK-GPG-KEY.pub fails through http from http://repo.saltstack.com

### DIFF
--- a/bootstrap-scripts/package-install.sh
+++ b/bootstrap-scripts/package-install.sh
@@ -39,7 +39,7 @@ if [ "x$DISTRO" == "xubuntu" ]; then
 
 if [ "x$ADD_ONLINE_REPOS" == "xYES" ]; then
   (curl -L 'https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/archive.key' | apt-key add - ) && echo 'deb [arch=amd64] https://archive.cloudera.com/cm5/ubuntu/trusty/amd64/cm/ trusty-cm5.9.0 contrib' > /etc/apt/sources.list.d/cloudera-manager.list
-  (curl -L 'http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
+  (curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list
   (curl -L 'https://deb.nodesource.com/gpgkey/nodesource.gpg.key' | apt-key add - ) && echo 'deb [arch=amd64] https://deb.nodesource.com/node_6.x trusty main' > /etc/apt/sources.list.d/nodesource.list
 fi
   apt-get update


### PR DESCRIPTION
Problem Statement:
=================
To make uniform across pnda-heat-template to pnda-aws-template of the Issue 121: SALTSTACK-GPG-KEY.pub fails through http from http://repo.saltstack.com. 

Analysis:
========
If the IT infrastructure in an organization not allowed http traffic, then getting the key from  "http://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub" will be failed,
because of that the deployment will not be successful.

Solution:
========
Fix : Change http to https 


Files Changed :
===============
scripts/package_install.sh
curl -L 'https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/SALTSTACK-GPG-KEY.pub' | apt-key add - ) && echo 'deb [arch=amd64] https://repo.saltstack.com/apt/ubuntu/14.04/amd64/archive/2015.8.11/ trusty main' > /etc/apt/sources.list.d/saltstack.list

Tests:
=====
1. Deploy in PNDA for PICO flavour for ubuntu
2. Deploy in PNDA for PICO flavour for RHEL