### PR TITLE
Fixes for #148 #149 #151 Ubuntu offline mode package install issue

### DIFF
--- a/cli/pnda-cli.py
+++ b/cli/pnda-cli.py
@@ -758,7 +758,12 @@ def main():
         else:
             print 'destroy command must specify pnda_cluster, e.g.\npnda-cli.py destroy -e squirrel-land'
             sys.exit(1)
-
+    REJECT_OUTBOUND = PNDA_ENV['connectivity']['REJECT_OUTBOUND']
+    ADD_ONLINE_REPOS = PNDA_ENV['connectivity']['ADD_ONLINE_REPOS']
+    if ADD_ONLINE_REPOS in ['YES',True] and REJECT_OUTBOUND in ['YES',True] :
+       print 'If REJECT_OUTBOUND is YES , ADD_ONLINE_REPOS must be NO , verify pnda_env.yaml File'
+       sys.exit(1)
+       
     while pnda_cluster is None:
         pnda_cluster = raw_input("Enter a name for the pnda cluster (e.g. squirrel-land): ")
         if not re.match(NAME_REGEX, pnda_cluster):

--- a/pnda_env_example.yaml
+++ b/pnda_env_example.yaml
@@ -138,12 +138,12 @@ elk-cluster:
   LOGSTASH_NODES: 0
 
 connectivity:
-  # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify YES to enable.
-  REJECT_OUTBOUND: YES
+  # Deploy an iptables ruleset to every node preventing outbound access to all hosts except the PNDA_MIRROR, NTP_SERVER and specified CLIENT_IP. Specify 'YES' to enable.
+  REJECT_OUTBOUND: 'YES'
   # If using REJECT_OUTBOUND, the IP address of the client that created PNDA
   CLIENT_IP: 1.1.1.1
   # Add online repositories for yum, apt-get, pip, etc alongside PNDA mirror
-  ADD_ONLINE_REPOS: NO
+  ADD_ONLINE_REPOS: 'NO'
 
 mine_functions:
   MINE_FUNCTIONS_NETWORK_IP_ADDRS_NIC: eth0


### PR DESCRIPTION
Fix for following issues:
1. Fixes #151    Ubuntu offline mode package install issue
2. Fixes #149    Ubuntu - REJECT OUTBOUND and ADD_ONLINE_REPOS as YES IPTable is not getting updated
3. Fixes #148    For REJECT_OUTBOUND IP tables is hardcoded 10.0.0.0/16 in package-install.sh

Changes: 
pnda-cli.py:
   Fix for Issue 149: exit the setup if user provide reject outbound  and add offline repos as 'YES'
Package-install.sh
   Fix for  Issue 148, removed the hardcoded VPC subnet.
   Fix for Issue 151 :  Added code for Ubuntu APT repo changes for offline
